### PR TITLE
Upgrading dependencies, especially to SIPSoceryMedia.Abstractions 1.2…

### DIFF
--- a/src/SIPSorceryMedia.Encoders.csproj
+++ b/src/SIPSorceryMedia.Encoders.csproj
@@ -9,11 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="SIPSorceryMedia.Abstractions" Version="1.0.4-pre" />
-  </ItemGroup>
-
-  <ItemGroup>
     <NativeLibs Include="$(MSBuildThisFileDirectory)\..\lib\x86\*.dll" Condition="'$(Platform)' == 'x86'" />
     <NativeLibs Include="$(MSBuildThisFileDirectory)\..\lib\x64\*.dll" Condition="'$(Platform)' == 'x64' or '$(Platform)' == 'AnyCPU'" />
     <Compile Remove="packages\**" />
@@ -26,6 +21,11 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <TargetPath>%(Filename)%(Extension)</TargetPath>
     </ContentWithTargetPath>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
+    <PackageReference Include="SIPSorceryMedia.Abstractions" Version="1.2.0" />
   </ItemGroup>
   
   <!--<PropertyGroup>

--- a/src/VideoEncoderEndPoint.cs
+++ b/src/VideoEncoderEndPoint.cs
@@ -61,6 +61,8 @@ namespace SIPSorceryMedia.Encoders
 
 #pragma warning disable CS0067
         public event SourceErrorDelegate OnVideoSourceError;
+        public event RawVideoSampleFasterDelegate OnVideoSourceRawSampleFaster;
+        public event VideoSinkSampleDecodedFasterDelegate OnVideoSinkDecodedSampleFaster;
 #pragma warning restore CS0067
 
         /// <summary>
@@ -143,6 +145,11 @@ namespace SIPSorceryMedia.Encoders
         public void Dispose()
         {
             _videoEncoder?.Dispose();
+        }
+
+        public void ExternalVideoSourceRawSampleFaster(uint durationMilliseconds, RawImage rawImage)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/VpxVideoEncoder.cs
+++ b/src/VpxVideoEncoder.cs
@@ -120,5 +120,15 @@ namespace SIPSorceryMedia.Encoders
             _vp8Encoder?.Dispose();
             _vp8Decoder?.Dispose();
         }
+
+        public byte[] EncodeVideoFaster(RawImage rawImage, VideoCodecsEnum codec)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<RawImage> DecodeVideoFaster(byte[] encodedSample, VideoPixelFormatsEnum pixelFormat, VideoCodecsEnum codec)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
…, required for SIPSocery WebRTC examples to function properly.