### PR TITLE
Enable generation of SIPSorceryMedia.Encoders.xml documentation file

### DIFF
--- a/src/SIPSorceryMedia.Encoders.csproj
+++ b/src/SIPSorceryMedia.Encoders.csproj
@@ -2,7 +2,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461;net8.0</TargetFrameworks>
-    <LangVersion>10.0</LangVersion> 
+    <LangVersion>10.0</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Disable warning for missing XML doc comments. -->
+    <NoWarn>$(NoWarn);CS1591;CS1573</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Same thing as https://github.com/sipsorcery-org/sipsorcery/pull/1106

* Enabled GenerateDocumentationFile in SIPSorceryMedia.Encoders.csproj
* Disabled the "missing XML comment" warnings